### PR TITLE
Merge the departure list into master

### DIFF
--- a/agency_common.py
+++ b/agency_common.py
@@ -79,3 +79,16 @@ class Agency(abc.ABC):
             An UnweightedEdge object
         '''
         raise NotImplementedError
+    @classmethod
+    def get_pickup(cls, from_node, datetime_depart):
+        '''
+        Finds trips that depart from from_node after datetime_depart. Yields an
+        edge from from_node to the trip's final destination for each trip.
+        
+        Like in get_edge, from_node is a string that may equal the name of a
+        bus stop or that may be what the user entered as the origin.
+        
+        If this method is not overridden, then it is simply an empty generator.
+        '''
+        return
+        yield

--- a/agency_common.py
+++ b/agency_common.py
@@ -91,6 +91,8 @@ class Agency(abc.ABC):
         '''
         Finds trips that depart from from_node after datetime_depart. Yields an
         edge from from_node to the trip's final destination for each trip.
+        Every yielded edge's departure time is later than or equal to the last
+        yielded edge's departure time.
         
         Like in get_edge, from_node is a string that may equal the name of a
         bus stop or that may be what the user entered as the origin.

--- a/agency_common.py
+++ b/agency_common.py
@@ -89,10 +89,10 @@ class Agency(abc.ABC):
     @classmethod
     def get_pickup(cls, from_node, datetime_depart):
         '''
-        Finds trips that depart from from_node after datetime_depart. Yields an
-        edge from from_node to the trip's final destination for each trip.
-        Every yielded edge's departure time is later than or equal to the last
-        yielded edge's departure time.
+        Finds trips that depart from from_node after datetime_depart. Yields a
+        Direction from from_node to the trip's final destination for each trip.
+        Every yielded Direction's departure time must be later than or equal to
+        the last yielded Direction's departure time.
         
         Like in get_edge, from_node is a string that may equal the name of a
         bus stop or that may be what the user entered as the origin.

--- a/agency_nyu.py
+++ b/agency_nyu.py
@@ -281,7 +281,7 @@ class AgencyNYU(Agency):
                         times = [
                             (row[from_node_index], row[-1])
                             for row in schedule.other_rows
-                            if from_node_index < len(row)
+                            if from_node_index < len(row) - 1
                             and row[from_node_index] is not None
                             and row[from_node_index].pickup
                         ]

--- a/agency_nyu.py
+++ b/agency_nyu.py
@@ -274,30 +274,17 @@ class AgencyNYU(Agency):
                 for schedule in schedule_by_day[date_depart.weekday()]:
                     for from_node_index \
                         in schedule.get_column_indices(from_node):
-                        last_column_index = schedule.get_last_column_index()
                         # Filter out the rows where the vehicle will not stop
-                        # and pick up passengers at from_node.
-                        times = []
-                        for row in schedule.other_rows:
-                            if from_node_index < len(row) and \
-                                row[from_node_index] is not None and \
-                                row[from_node_index].pickup:
-                                # Find the last stop in this trip by looking
-                                # from the last column to the left.
-                                for to_node_index in range(
-                                    last_column_index,
-                                    from_node_index,
-                                    -1
-                                ):
-                                    if to_node_index < len(row) and \
-                                        row[to_node_index] is not None:
-                                        times.append(
-                                            (
-                                                row[from_node_index],
-                                                row[to_node_index]
-                                            )
-                                        )
-                                        break
+                        # and pick up passengers at from_node. Recall that
+                        # row[-1] is guaranteed not to be None by
+                        # parse_schedule_row in pickle_nyu.py.
+                        times = [
+                            (row[from_node_index], row[-1])
+                            for row in schedule.other_rows
+                            if from_node_index < len(row)
+                            and row[from_node_index] is not None
+                            and row[from_node_index].pickup
+                        ]
                         # Find the first row in the schedule where the
                         # departure time is greater than timedelta_depart. We
                         # only want to look at this row and the rows in the

--- a/agency_nyu.py
+++ b/agency_nyu.py
@@ -239,3 +239,125 @@ class AgencyNYU(Agency):
                     break
             else:
                 break
+    @classmethod
+    def get_pickup(cls, from_node, datetime_depart):
+        date_depart, timedelta_depart = timedelta_after_midnight(
+            datetime_depart
+        )
+        # To account for schedules that run past midnight and from the previous
+        # day, we start our search in the previous day but with one day added
+        # to the timedelta.
+        try:
+            date_depart -= ONE_DAY
+        except OverflowError:
+            pass
+        else:
+            timedelta_depart += ONE_DAY
+        last_departure = datetime.datetime.min
+        # Use a priority queue as a buffer for edges. This allows us to make
+        # sure that we have scanned all the schedules at least one day ahead
+        # before we determine which is the soonest trip and yield it.
+        edges_heap = []
+        date_overflowed = False
+        days_without_edges = 0
+        # Yield edges until we hit the maximum date.
+        while True:
+            # If the departure times of the edges in the buffer do not span at
+            # least a day, compute more edges. If no departures are seen in
+            # seven days, just stop; there will not be any more because the
+            # schedules repeat every week.
+            if days_without_edges < 7 and (
+                not edges_heap or
+                (last_departure - edges_heap[0].edge.datetime_depart) < ONE_DAY
+            ) and not date_overflowed:
+                days_without_edges += 1
+                for schedule in schedule_by_day[date_depart.weekday()]:
+                    for from_node_index \
+                        in schedule.get_column_indices(from_node):
+                        last_column_index = schedule.get_last_column_index()
+                        # Filter out the rows where the vehicle will not stop
+                        # and pick up passengers at from_node.
+                        times = []
+                        for row in schedule.other_rows:
+                            if from_node_index < len(row) and \
+                                row[from_node_index] is not None and \
+                                row[from_node_index].pickup:
+                                # Find the last stop in this trip by looking
+                                # from the last column to the left.
+                                for to_node_index in range(
+                                    last_column_index,
+                                    from_node_index,
+                                    -1
+                                ):
+                                    if to_node_index < len(row) and \
+                                        row[to_node_index] is not None:
+                                        times.append(
+                                            (
+                                                row[from_node_index],
+                                                row[to_node_index]
+                                            )
+                                        )
+                                        break
+                        # Find the first row in the schedule where the
+                        # departure time is greater than timedelta_depart. We
+                        # only want to look at this row and the rows in the
+                        # schedule that are below this row.
+                        try:
+                            starting_index = first_greater_than(
+                                times,
+                                timedelta_depart,
+                                lambda x: x[0].time
+                            )
+                        except ValueError:
+                            pass
+                        else:
+                            for row in itertools.islice(
+                                times,
+                                starting_index,
+                                None
+                            ):
+                                # Add the edge.
+                                d = datetime.datetime.combine(
+                                    date_depart,
+                                    MIDNIGHT
+                                ) + row[0].time
+                                a = datetime.datetime.combine(
+                                    date_depart,
+                                    MIDNIGHT
+                                ) + row[1].time
+                                heapq.heappush(
+                                    edges_heap,
+                                    EdgeHeapQKey(
+                                        a - datetime.datetime.min,
+                                        cls.UnweightedEdge(
+                                            d,
+                                            a,
+                                            "Take Route " +
+                                            schedule.route + "." +
+                                            (
+                                                " Signal driver to stop."
+                                                if row[1].soft
+                                                else ""
+                                            )
+                                        )
+                                    )
+                                )
+                                if d > last_departure:
+                                    last_departure = d
+                                days_without_edges = 0
+                # Increment the day and continue.
+                try:
+                    date_depart += ONE_DAY
+                except OverflowError:
+                    date_overflowed = True
+                else:
+                    if timedelta_depart < ONE_DAY:
+                        timedelta_depart = JUST_BEFORE_MIDNIGHT
+                    else:
+                        timedelta_depart -= ONE_DAY
+                # Check again whether more edges need to be computed.
+                continue
+            if edges_heap:
+                yield heapq.heappop(edges_heap).edge
+            else:
+                break

--- a/common_nyu.py
+++ b/common_nyu.py
@@ -57,12 +57,6 @@ class NYUSchedule:
         for i, v in enumerate(self.header_row):
             if v == from_node:
                 yield i
-    def get_last_column_index(self):
-        '''
-        Returns the index of the last column in the schedule. This is useful if
-        you want to reference the last stop in a trip.
-        '''
-        return len(self.header_row) - 1
 @attr.s
 class NYUTime:
     def __str__(self):

--- a/common_nyu.py
+++ b/common_nyu.py
@@ -57,6 +57,12 @@ class NYUSchedule:
         for i, v in enumerate(self.header_row):
             if v == from_node:
                 yield i
+    def get_last_column_index(self):
+        '''
+        Returns the index of the last column in the schedule. This is useful if
+        you want to reference the last stop in a trip.
+        '''
+        return len(self.header_row) - 1
 @attr.s
 class NYUTime:
     def __str__(self):

--- a/departure_lister.py
+++ b/departure_lister.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import collections, operator
+class IteratorPeeker:
+    '''
+    This class stores the next value from an iterator. You can call peek() to
+    peek at this value as many times as you want. When you want the next value
+    to be available, just call next().
+    '''
+    def __init__(self, iterator):
+        self._stop_iteration = False
+        self._iterator = iterator
+        self._next = None
+        self.next()
+    def next(self):
+        try:
+            self._next = next(self._iterator)
+        except StopIteration:
+            self._stop_iteration = True
+    def peek(self):
+        if self._stop_iteration:
+            raise StopIteration
+        return self._next
+def merge_selection(iterators, key=lambda x: x):
+    '''
+    This function yields values from the given iterators from smallest to
+    largest. If two values are equal, the one from the iterator that is first
+    in the arguments is yielded. This is consistent with built-in stability-
+    preserving functions in Python.
+    
+    This function assumes that the iterators produce values from smallest to
+    largest and that all the values from all the iterators can be compared
+    with each other using the < operator.
+    
+    If the key argument is specified, then key(x) < key(y) will be used instead
+    of x < y when determining the smallest value.
+    '''
+    # Create an IteratorPeeker for every iterator.
+    # collections.deque is implemented in Python as a doubly-linked list.
+    peekers = collections.deque(
+        IteratorPeeker(iterator) for iterator in iterators
+    )
+    while peekers:
+        # Peek the next values from the iterators.
+        smallest_value = None
+        peeker_smallest_value = None
+        for peeker_index, peeker in enumerate(peekers):
+            try:
+                value = peeker.peek()
+            except StopIteration:
+                # This iterator has been fully consumed. Delete it.
+                del peekers[peeker_index]
+                # Go around! Now that the deque has mutated, it is a
+                # RuntimeError to continue this iteration.
+                smallest_value = None
+                break
+            if smallest_value is None or key(value) < key(smallest_value):
+                smallest_value = value
+                peeker_smallest_value = peeker
+        # Find the smallest value.
+        if smallest_value is not None:
+            yield smallest_value
+            peeker_smallest_value.next()
+def departure_list(agencies, from_node, datetime_depart, max_count=None):
+    '''
+    Combines Directions that depart from from_node after datetime_depart from
+    multiple agencies and yields them in order from earliest to latest.
+    
+    Arguments:
+        agencies:
+            an iterable of subclasses of agency_common.Agency
+        from_node:
+            a string that is either:
+                a) the name of a bus stop, or
+                b) whatever the user entered as the origin.
+    '''
+    for edge in merge_selection(
+        (agency.get_pickup(from_node, datetime_depart) for agency in agencies),
+        operator.attrgetter("datetime_depart")
+    ):
+        if max_count is not None:
+            max_count -= 1
+            if max_count < 0:
+                return
+        yield edge

--- a/get_itinerary.py
+++ b/get_itinerary.py
@@ -49,8 +49,9 @@ def parse_args(agencies=()):
         default=0,
         metavar="N",
         help=
-            "if set, instead of directions to the destination, the next N "
-            "departures from the origin after datetime are returned"
+            "(implies --depart) if set, instead of directions to the "
+            "destination, the next N departures from the origin after datetime "
+            "are returned"
     )
     # Allow agencies to add their own arguments.
     for agency in agencies:

--- a/get_itinerary.py
+++ b/get_itinerary.py
@@ -22,7 +22,9 @@ def parse_args(agencies=()):
     )
     arg_parser.add_argument(
         "destination",
-        help="the place that you want to go to"
+        help="the place that you want to go to",
+        nargs="?",
+        default=""
     )
     arg_parser.add_argument(
         "datetime",
@@ -38,11 +40,33 @@ def parse_args(agencies=()):
         action="store_true",
         help="modifies the behavior of datetime (see above)"
     )
+    arg_parser.add_argument(
+        "-l",
+        "--list-departures",
+        type=int,
+        nargs="?",
+        const=2,
+        default=0,
+        metavar="N",
+        help=
+            "if set, instead of directions to the destination, the next N "
+            "departures from the origin after datetime are returned"
+    )
     # Allow agencies to add their own arguments.
     for agency in agencies:
         agency.add_arguments(arg_parser.add_argument)
     # Parse the arguments.
     args_parsed = arg_parser.parse_args()
+    # Check that the destination or --list-departures was specified and that
+    # only one, not both, was specified.
+    if args_parsed.destination and args_parsed.list_departures:
+        arg_parser.error(
+            "the destination and --list-departures are mutually exclusive"
+        )
+    elif not args_parsed.destination and not args_parsed.list_departures:
+        arg_parser.error(
+            "either the destination or --list-departures is required"
+        )
     # Pass the parsed arguments to the agencies.
     for agency in agencies:
         agency.handle_parsed_arguments(args_parsed)

--- a/get_itinerary.py
+++ b/get_itinerary.py
@@ -5,6 +5,7 @@ from common import NODE_LIST_TXT
 from agency_common import Agency
 from agency_nyu import AgencyNYU
 from agency_walking_static import AgencyWalkingStatic
+from departure_lister import departure_list
 
 def parse_args(agencies=()):
     arg_parser = argparse.ArgumentParser(
@@ -101,9 +102,18 @@ def main():
     )
     assert all(issubclass(a, Agency) or isinstance(a, Agency) for a in agencies)
     args_parsed = parse_args(agencies)
-    if False:
-        pass
+    if args_parsed.list_departures:
+        # The user asked for a list of departures from the origin.
+        print("Departures:")
+        for direction in departure_list(
+            agencies,
+            args_parsed.origin,
+            args_parsed.datetime,
+            args_parsed.list_departures
+        ):
+            print(" -", direction)
     else:
+        # The user specified a destination.
         if args_parsed.origin != args_parsed.destination:
             pathfinder = ShortestPathFinder(nodes, agencies)
             trip = pathfinder.find_trip(

--- a/pickle_nyu.py
+++ b/pickle_nyu.py
@@ -202,6 +202,7 @@ def parse_schedule_row(header_row, row, show_parse_error=True):
         if result_cell is not None:
             last_header = h
             last_delta = result_cell
+    # Strip None values from the end of the list.
     while result_row and result_row[-1] is None:
         result_row.pop()
     return result_row


### PR DESCRIPTION
After this pull request is merged, `get_itinerary.py` will be able to list the next `n` trips that are departing from the specified origin after the specified time with the `--list-departures` option. For example, to see the next five departures from 6 MetroTech, run `get_itinerary.py "6 MetroTech" now --list-departures=5` on Windows or `./get_itinerary.py "6 MetroTech" now --list-departures=5` on Linux. (`now` simply means the current date and time.)